### PR TITLE
Replace egrep pattern from 'LANGUAGE' to 'LANG'

### DIFF
--- a/lynis
+++ b/lynis
@@ -99,7 +99,7 @@ Make sure to execute ${PROGRAM_NAME} from untarred directory or check your insta
     fi
 
     # Auto detection of language based on locale (first two characters)
-    LANGUAGE=$(locale | egrep "^LANGUAGE=" | cut -d= -f2 | cut -d_ -f1)
+    LANGUAGE=$(locale | egrep "^LANG=" | cut -d= -f2 | cut -d_ -f1)
 #
 #################################################################################
 #


### PR DESCRIPTION
I run the command under CentOS 7.2 using bash and the result was empty:
`locale | egrep "^LANGUAGE=" | cut -d= -f2 | cut -d_ -f1`

After that I run locale command and the 'LANGUAGE' variable is missed, but I had found variable with 'LANG'.
